### PR TITLE
Firewall proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ See the [streaming API docs][api-docs] for examples of the limit and delete comm
     var twit = new TwitterNode({
       user: 'username', 
       password: 'password',
+      host: 'my_proxy.my_company.com',         // proxy server name or ip addr
+      port: 8080,							   // proxy port!
       track: ['baseball', 'football'],         // sports!
       follow: [12345, 67890],                  // follow these random users
       locations: [-122.75, 36.8, -121.75, 37.8] // tweets in SF

--- a/lib/twitter-node/index.js
+++ b/lib/twitter-node/index.js
@@ -19,8 +19,8 @@ function extend(a, b) {
 //
 // Valid option keys:
 //
-// port      - Integer of the streaming api connection port.  Defaults to 80.
-// host      - String of the streaming api host.  Defaults to 'stream.twitter.com'.
+// port      - Integer of proxy port
+// host      - String or ip address of the proxy server
 // path      - String of the base path for the request.
 // action    - String part of the URL that specifies what to query for.
 // track     - Array of keywords to filter.  See track()
@@ -113,7 +113,7 @@ TwitterNode.prototype.stream = function stream() {
       twit    = this,
       request;
 
-  headers['Host'] = this.host;
+  headers['Host'] = 'stream.twitter.com';
 
   if (this.user) {
     headers['Authorization'] = basicAuth(this.user, this.password);
@@ -157,7 +157,7 @@ TwitterNode.prototype._receive = function(chunk) {
 //
 // returns Http Client instance.
 TwitterNode.prototype._createClient = function(port, host) {
-  return http.createClient(this.port, this.host);
+  return http.createClient(port, host)
 };
 
 // Builds the URL for the streaming request.


### PR DESCRIPTION
Make the host and port parameter of httpClient to be the proxy's host and port values to enable working behind the firewall.
The real host and port are configured through http header.

Tested and works fine.
