### PR TITLE
Update for SSL

### DIFF
--- a/lib/twitter-node/index.js
+++ b/lib/twitter-node/index.js
@@ -1,4 +1,4 @@
-var http         = require('http'),
+var https        = require('https'),
     query        = require('querystring'),
     Parser       = require('./parser'),
     EventEmitter = require('events').EventEmitter,
@@ -35,7 +35,7 @@ var TwitterNode = exports.TwitterNode = function(options) {
   EventEmitter.call(this);
   if(!options) options = {};
   var self           = this;
-  this.port          = options.port      || 80;
+  this.port          = options.port      || 443;
   this.host          = options.host      || 'stream.twitter.com';
   this.path          = options.path      || '/1/statuses/';
   this.action        = options.action    || 'filter';
@@ -108,8 +108,7 @@ TwitterNode.prototype.stream = function stream() {
 
   if (this.action === 'filter' && this.buildParams() === '') return;
 
-  var client  = this._createClient(this.port, this.host),
-      headers = extend({}, this.headers),
+  var headers = extend({}, this.headers),
       twit    = this,
       request;
 
@@ -119,21 +118,29 @@ TwitterNode.prototype.stream = function stream() {
     headers['Authorization'] = basicAuth(this.user, this.password);
   }
 
-  request = client.request("GET", this.requestUrl(), headers);
+  var requestOptions = {
+    host: this.host,
+    port: this.port,
+    path: this.requestUrl(),
+    method: 'POST',
+    headers: headers
+  };
 
-  request.addListener('response', function(response) {
+  request = https.request(requestOptions, function(response) {
     twit._clientResponse = response;
-
-    response.addListener('data', function(chunk) {
+      
+    response.on('data', function(chunk){
       twit._receive(chunk);
     });
-
-    response.addListener('end', function() {
+      
+    response.on('end', function() {
       twit.emit('end', this);
       twit.emit('close', this);
     });
   });
+  
   request.end();
+  
   return this;
 };
 
@@ -147,17 +154,6 @@ TwitterNode.prototype.stream = function stream() {
 TwitterNode.prototype._receive = function(chunk) {
   this.parser.receive(chunk);
   return this;
-};
-
-// Creates the HTTP client object for the stream connection.  Override this
-// to pass in your own client if needed.
-//
-// port - Integer port number to connect to.
-// host - String host name to connect to.
-//
-// returns Http Client instance.
-TwitterNode.prototype._createClient = function(port, host) {
-  return http.createClient(port, host)
 };
 
 // Builds the URL for the streaming request.


### PR DESCRIPTION
The Twitter Streaming API now only accepts connections over HTTPS. This update attempts to implement that. I am not a Node.js expert, but this is working for me so I thought I would submit a pull in case others needed it. Please let me know if something looks wrong. Thanks.
