### PR TITLE
Converted twitter stream requests to secure (https)

### DIFF
--- a/lib/twitter-node/index.js
+++ b/lib/twitter-node/index.js
@@ -1,4 +1,4 @@
-var https        = require('https'),
+var https 		 = require('https'), 
     query        = require('querystring'),
     Parser       = require('./parser'),
     EventEmitter = require('events').EventEmitter,
@@ -45,7 +45,8 @@ var TwitterNode = exports.TwitterNode = function(options) {
   this.params        = options.params    || {};
   this.user          = options.user;
   this.password      = options.password;
-  this.headers       = { "User-Agent": 'Twitter-Node' };
+  this.headers 		 = { 'User-Agent' : 'Twitter-Node' }
+  this.options       = { port: this.port, host: this.host, method: 'GET', agent: false, headers: this.headers };
   this.debug         = false;
   this.parser        = new Parser();
   this.parser.addListener('object', processJSONObject(this));
@@ -108,39 +109,31 @@ TwitterNode.prototype.stream = function stream() {
 
   if (this.action === 'filter' && this.buildParams() === '') return;
 
-  var headers = extend({}, this.headers),
+  var options = extend(this.options, { headers: this.headers }),
       twit    = this,
       request;
-
-  headers['Host'] = this.host;
-
+	
+  options.path = this.requestUrl();
+	
   if (this.user) {
-    headers['Authorization'] = basicAuth(this.user, this.password);
+    options.headers["Authorization"] = basicAuth(this.user, this.password);
   }
 
-  var requestOptions = {
-    host: this.host,
-    port: this.port,
-    path: this.requestUrl(),
-    method: 'POST',
-    headers: headers
-  };
+  request = https.request(options, function (response) {
 
-  request = https.request(requestOptions, function(response) {
-    twit._clientResponse = response;
-      
-    response.on('data', function(chunk){
-      twit._receive(chunk);
-    });
-      
-    response.on('end', function() {
-      twit.emit('end', this);
-      twit.emit('close', this);
-    });
+	twit._clientResponse = response;
+
+	response.on('data', function(chunk) {
+	  twit._receive(chunk);
+	});
+
+	response.on('end', function() {
+	  twit.emit('end', this);
+	  twit.emit('close', this);
+	});
+		
   });
-  
   request.end();
-  
   return this;
 };
 


### PR DESCRIPTION
My node app (emotiglobe.com) just recently stopped accessing the twitter stream 

I went to Twitter's doco and all the examples on the page are in https: 
https://dev.twitter.com/docs/streaming-api/methods

Which led me to believe that Twitter might have disabled the plain http requests

So I converted your request to https (under the new node.js spec) and got it working locally. 

Hope you approve and commit to the official library so I can npm the update to my live site. 

PS. I was careful to make the updates without changing your API so all apps using the library should not be affected by the upgrade. 
