### PR TITLE
Fix for Issue #6 "reconnect on failure ?"

### DIFF
--- a/lib/twitter-node/index.js
+++ b/lib/twitter-node/index.js
@@ -132,7 +132,12 @@ TwitterNode.prototype.stream = function stream() {
 
   request = https.request(requestOptions, function(response) {
     twit._clientResponse = response;
-      
+
+    response.on('close', function(err){
+      // If underlaying connection was terminated reconnect to the stream
+      twit.stream();
+    });
+
     response.on('data', function(chunk){
       twit._receive(chunk);
     });

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "twitter-node",
   "description": "node.js stream API for the twitter streaming HTTP API",
-  "version": "0.0.2",
-  "author": "technoweenie",
+  "version": "0.0.3",
+  "author": {"name": "technoweenie"},
+  "contributors": [
+    {"name": "cvee"}
+  ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/technoweenie/twitter-node.git"
+    "url": "http://github.com/istrategylabs/twitter-node.git"
   },
   "engine": [ "node >=0.2.0" ],
   "main": "./lib/twitter-node"


### PR DESCRIPTION
Attached is a fix for issue #6. It involves adding a listener for the http.ServerRequest event 'close'. If the event is triggered, twit.stream() is called to restart the connection.
