### PR TITLE
Why not emit the close event from the HTTPS request?

### DIFF
--- a/lib/twitter-node/index.js
+++ b/lib/twitter-node/index.js
@@ -139,6 +139,8 @@ TwitterNode.prototype.stream = function stream() {
       
     response.on('end', function() {
       twit.emit('end', this);
+    });
+    response.on('close', function() {
       twit.emit('close', this);
     });
   });


### PR DESCRIPTION
In your code you are doing:

```
response.on('end', function() {
  twit.emit('end', this);
  twit.emit('close', this);
});
```

I've found that the following listener setup is necessary to know that the connection is closed (i.e. unexpected socket close, which happens when you connect a second application using the same credentials.). In fact, in our experience we rarely see any "end" events emitted when using the Firehose.

```
response.on('end', function() {
  twit.emit('end', this);
});
response.on('close', function() {
  twit.emit('close', this);
});
```
