### PR TITLE
Remove unused 'sys'.

### DIFF
--- a/lib/twitter-node/parser.js
+++ b/lib/twitter-node/parser.js
@@ -1,5 +1,3 @@
-var sys = require('sys')
-
 // glorious streaming json parser, built specifically for the twitter streaming api
 // assumptions:
 //   1) ninjas are mammals


### PR DESCRIPTION
Removes an unused "require('sys')".

require('sys') complains in node > 0.5.
